### PR TITLE
Update canvas usage to remove use of DPI

### DIFF
--- a/changes/12.bugfix.rst
+++ b/changes/12.bugfix.rst
@@ -1,0 +1,1 @@
+Removed use of DPI-based canvas APIs.

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ include_package_data = True
 package_dir=
     = src
 install_requires =
-    toga >= 0.3.0.dev19
+    toga >= 0.3.0.dev22
     matplotlib >= 3.0.3
 
 [options.packages.find]

--- a/src/toga_chart/chart.py
+++ b/src/toga_chart/chart.py
@@ -34,7 +34,7 @@ class Chart(Canvas, FigureCanvasBase):
         self.figure = figure
         FigureCanvasBase.__init__(self, self.figure)
         l, b, w, h = self.figure.bbox.bounds
-        renderer = ChartRenderer(self, w, h, self._impl.container.viewport.dpi)
+        renderer = ChartRenderer(self, w, h)
         self.figure.draw(renderer)
 
 
@@ -46,10 +46,8 @@ class ChartRenderer(RendererBase):
         renderer (:obj:`Canvas`):  canvas to render onto
         width (int): width of canvas
         height (int): height of canvas
-        dpi (int): dots per inch of the canvas
     """
-    def __init__(self, renderer, width, height, dpi):
-        self.dpi = dpi
+    def __init__(self, renderer, width, height):
         self.width = width
         self.height = height
         self._renderer = renderer
@@ -134,10 +132,8 @@ class ChartRenderer(RendererBase):
         get the width and height in display coords of the string s
         with FontPropertry prop
         """
-
         font = self.get_font(prop)
-
-        w, h = font.measure(s, dpi=self.dpi)
+        w, h = self._renderer.measure_text(s, font)
         return w, h, 1
 
     def get_font(self, prop):
@@ -157,6 +153,3 @@ class ChartRenderer(RendererBase):
 
     def to_toga_color(self, r, g, b, a):
         return parse_color(rgba(r * 255, g * 255, b * 255, a))
-
-    def points_to_pixels(self, points):
-        return points * self.dpi / 72


### PR DESCRIPTION
The Toga canvas API was modified to make font measurement a direct function of the canvas. This removes the need to have any DPI handling in toga-chart itself.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
