### PR TITLE
Figure now resizes to fit the window

### DIFF
--- a/changes/14.feature.rst
+++ b/changes/14.feature.rst
@@ -1,0 +1,1 @@
+Chart now has an ``on_draw()`` handler to ensure the chart auto-resizes.

--- a/docs/requirements_docs.txt
+++ b/docs/requirements_docs.txt
@@ -3,4 +3,4 @@ sphinxcontrib-spelling
 pyenchant
 sphinx-autobuild
 sphinx_rtd_theme
-sphinx_tabs==1.1.8
+sphinx_tabs

--- a/examples/chart/app.py
+++ b/examples/chart/app.py
@@ -6,39 +6,45 @@ import numpy as np
 from toga.constants import COLUMN
 
 
-def sample_histogram():
-    np.random.seed(19680801)
-
-    # example data
-    mu = 100  # mean of distribution
-    sigma = 15  # standard deviation of distribution
-    x = mu + sigma * np.random.randn(437)
-
-    num_bins = 50
-
-    f = Figure(figsize=(5, 4))
-    ax = f.add_subplot(1, 1, 1)
-
-    # the histogram of the data
-    n, bins, patches = ax.hist(x, num_bins, density=1)
-
-    # add a 'best fit' line
-    y = ((1 / (np.sqrt(2 * np.pi) * sigma)) * np.exp(-0.5 * (1 / sigma * (bins - mu))**2))
-    ax.plot(bins, y, '--')
-    ax.set_xlabel('Value')
-    ax.set_ylabel('Probability density')
-    ax.set_title(r'Histogram: $\mu=100$, $\sigma=15$')
-
-    return f
-
-
 class ExampleChartApp(toga.App):
 
+    def draw_chart(self):
+        # example data
+        mu = 100  # mean of distribution
+        sigma = 15  # standard deviation of distribution
+        x = mu + sigma * np.random.randn(437)
+
+        num_bins = 50
+
+        dpi = 100  # as of writing, 100 is also the default DPI for matplotlib.figure.Figure
+        f = Figure(figsize=(self.chart.layout.content_width / dpi, self.chart.layout.content_height / dpi), dpi=dpi)
+        ax = f.add_subplot(1, 1, 1)
+
+        # the histogram of the data
+        n, bins, patches = ax.hist(x, num_bins, density=1)
+
+        # add a 'best fit' line
+        y = ((1 / (np.sqrt(2 * np.pi) * sigma)) * np.exp(-0.5 * (1 / sigma * (bins - mu))**2))
+        ax.plot(bins, y, '--')
+        ax.set_xlabel('Value')
+        ax.set_ylabel('Probability density')
+        ax.set_title(r'Histogram: $\mu=100$, $\sigma=15$')
+
+        f.tight_layout()
+        return f
+
+
+    def on_resize(self, *args, **kwargs):
+        self.chart.draw(self.draw_chart())
+
+
     def startup(self):
+        np.random.seed(19680801)
+
         # Set up main window
         self.main_window = toga.MainWindow(title=self.name)
 
-        self.chart = toga_chart.Chart(style=Pack(flex=1))
+        self.chart = toga_chart.Chart(style=Pack(flex=1), on_resize=self.on_resize)
 
         self.main_window.content = toga.Box(
             children=[
@@ -47,7 +53,7 @@ class ExampleChartApp(toga.App):
             style=Pack(direction=COLUMN)
         )
 
-        self.chart.draw(sample_histogram())
+        self.chart.draw(self.draw_chart())
 
         self.main_window.show()
 

--- a/examples/chart/app.py
+++ b/examples/chart/app.py
@@ -1,14 +1,12 @@
 import toga
 import toga_chart
 from toga.style import Pack
-from matplotlib.figure import Figure
 import numpy as np
 from toga.constants import COLUMN
 
 
 class ExampleChartApp(toga.App):
-
-    def draw_chart(self):
+    def draw_chart(self, chart, figure, *args, **kwargs):
         # example data
         mu = 100  # mean of distribution
         sigma = 15  # standard deviation of distribution
@@ -16,12 +14,7 @@ class ExampleChartApp(toga.App):
 
         num_bins = 50
 
-        dpi = 100  # as of writing, 100 is also the default DPI for matplotlib.figure.Figure
-        # width and height can sometimes be 0 on initial rendering, so this gives a default value
-        width  = 4.52 if self.chart.layout.content_width  == 0 else self.chart.layout.content_width  / dpi
-        height = 6.4  if self.chart.layout.content_height == 0 else self.chart.layout.content_height / dpi
-        f = Figure(figsize=(width, height), dpi=dpi)
-        ax = f.add_subplot(1, 1, 1)
+        ax = figure.add_subplot(1, 1, 1)
 
         # the histogram of the data
         n, bins, patches = ax.hist(x, num_bins, density=1)
@@ -33,13 +26,10 @@ class ExampleChartApp(toga.App):
         ax.set_ylabel('Probability density')
         ax.set_title(r'Histogram: $\mu=100$, $\sigma=15$')
 
-        f.tight_layout()
-        return f
+        figure.tight_layout()
 
-
-    def on_resize(self, *args, **kwargs):
-        self.chart.draw(self.draw_chart())
-
+    def resize(self, *args, **kwargs):
+        pass
 
     def startup(self):
         np.random.seed(19680801)
@@ -47,7 +37,7 @@ class ExampleChartApp(toga.App):
         # Set up main window
         self.main_window = toga.MainWindow(title=self.name)
 
-        self.chart = toga_chart.Chart(style=Pack(flex=1), on_resize=self.on_resize)
+        self.chart = toga_chart.Chart(style=Pack(flex=1), on_resize=self.resize, on_draw=self.draw_chart)
 
         self.main_window.content = toga.Box(
             children=[
@@ -55,8 +45,6 @@ class ExampleChartApp(toga.App):
             ],
             style=Pack(direction=COLUMN)
         )
-
-        # self.chart.draw(self.draw_chart()) # this is not required here since we are redrawing on resize
 
         self.main_window.show()
 

--- a/examples/chart/app.py
+++ b/examples/chart/app.py
@@ -17,7 +17,10 @@ class ExampleChartApp(toga.App):
         num_bins = 50
 
         dpi = 100  # as of writing, 100 is also the default DPI for matplotlib.figure.Figure
-        f = Figure(figsize=(self.chart.layout.content_width / dpi, self.chart.layout.content_height / dpi), dpi=dpi)
+        # width and height can sometimes be 0 on initial rendering, so this gives a default value
+        width  = 4.52 if self.chart.layout.content_width  == 0 else self.chart.layout.content_width  / dpi
+        height = 6.4  if self.chart.layout.content_height == 0 else self.chart.layout.content_height / dpi
+        f = Figure(figsize=(width, height), dpi=dpi)
         ax = f.add_subplot(1, 1, 1)
 
         # the histogram of the data
@@ -53,7 +56,7 @@ class ExampleChartApp(toga.App):
             style=Pack(direction=COLUMN)
         )
 
-        self.chart.draw(self.draw_chart())
+        # self.chart.draw(self.draw_chart()) # this is not required here since we are redrawing on resize
 
         self.main_window.show()
 

--- a/src/toga_chart/chart.py
+++ b/src/toga_chart/chart.py
@@ -18,12 +18,13 @@ class Chart(Canvas, FigureCanvasBase):
         id (str):  An identifier for this widget.
         style (:obj:`Style`): An optional style object. If no
             style is provided then a new one will be created for the widget.
+        on_resize (:obj:`callable`): Handler to invoke when the canvas is resized.
         factory (:obj:`module`): A python module that is capable to return a
             implementation of this class with the same name. (optional &
             normally not needed)
     """
-    def __init__(self, id=None, style=None, factory=None):
-        Canvas.__init__(self, id=id, style=style, factory=factory)
+    def __init__(self, id=None, style=None, on_resize=None, factory=None):
+        Canvas.__init__(self, id=id, style=style, on_resize=on_resize, factory=factory)
 
     def draw(self, figure):
         """Draws the matplotlib figure onto the canvas


### PR DESCRIPTION
- Added `on_resize` to init so it can be used by the user
- Updated example to automagically resize the plot to the window size (it's a little laggy, but way better than having it be a fixed size)

I was going to add something to make it deal with resizing the figure on it's own, but I didn't see a clean way to do it.  So if you see one I can add it.

Let me know if you want anything changed.