### PR TITLE
Fix bug in towncrier-check

### DIFF
--- a/changes/18.bugfix.rst
+++ b/changes/18.bugfix.rst
@@ -1,0 +1,2 @@
+Fix bug in `towncrier-check` that it will compare PR branch to `origin/main`
+instead of `origin/master`.

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@ skip_install = True
 deps =
     {[testenv:towncrier]deps}
 commands =
-    python -m towncrier.check
+    python -m towncrier.check --compare-with=origin/main
 
 [testenv:towncrier]
 skip_install = True


### PR DESCRIPTION
The `towncrier-check` command is failing because it is trying to compare the PR branch with `origin/master`, which no longer exists.

This PR changes that so it compares the branch with `origin/main`.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
