### PR TITLE
Introduce build figure

### DIFF
--- a/changes/20.feature.rst
+++ b/changes/20.feature.rst
@@ -1,0 +1,1 @@
+introduce `Chart.build_figure` to create a figure with the right size.

--- a/examples/chart/app.py
+++ b/examples/chart/app.py
@@ -40,7 +40,11 @@ class ExampleChartApp(toga.App):
         self.main_window.content = toga.Box(
             children=[
                 self.chart,
-                toga.Button("Recreate Data", on_press=self.on_recreate_press)
+                toga.Button(
+                    "Recreate Data",
+                    on_press=self.on_recreate_press,
+                    style=Pack(padding_bottom=10, padding_top=10)
+                )
             ],
             style=Pack(direction=COLUMN)
         )

--- a/examples/chart/app.py
+++ b/examples/chart/app.py
@@ -6,21 +6,20 @@ from toga.constants import COLUMN
 
 
 class ExampleChartApp(toga.App):
+    mu = 100  # mean of distribution
+    sigma = 15  # standard deviation of distribution
+
     def draw_chart(self, chart, figure, *args, **kwargs):
-        # Generate some example data
-        mu = 100  # mean of distribution
-        sigma = 15  # standard deviation of distribution
-        x = mu + sigma * np.random.randn(437)
 
         num_bins = 50
 
         # Add a subplot that is a histogram of the data,
         # using the normal matplotlib API
         ax = figure.add_subplot(1, 1, 1)
-        n, bins, patches = ax.hist(x, num_bins, density=1)
+        n, bins, patches = ax.hist(self.x, num_bins, density=1)
 
         # add a 'best fit' line
-        y = ((1 / (np.sqrt(2 * np.pi) * sigma)) * np.exp(-0.5 * (1 / sigma * (bins - mu))**2))
+        y = ((1 / (np.sqrt(2 * np.pi) * self.sigma)) * np.exp(-0.5 * (1 / self.sigma * (bins - self.mu))**2))
         ax.plot(bins, y, '--')
 
         ax.set_xlabel('Value')
@@ -31,6 +30,7 @@ class ExampleChartApp(toga.App):
 
     def startup(self):
         np.random.seed(19680801)
+        self.recreate_data()
 
         # Set up main window
         self.main_window = toga.MainWindow(title=self.name)
@@ -40,11 +40,20 @@ class ExampleChartApp(toga.App):
         self.main_window.content = toga.Box(
             children=[
                 self.chart,
+                toga.Button("Recreate Data", on_press=self.on_recreate_press)
             ],
             style=Pack(direction=COLUMN)
         )
 
         self.main_window.show()
+
+    def recreate_data(self):
+        # Generate some example data
+        self.x = self.mu + self.sigma * np.random.normal(size=500)
+
+    def on_recreate_press(self, widget):
+        self.recreate_data()
+        self.chart.draw(self.chart.build_figure())
 
 
 def main():

--- a/src/toga_chart/chart.py
+++ b/src/toga_chart/chart.py
@@ -55,7 +55,11 @@ class Chart(Canvas, FigureCanvasBase):
         figure.draw(renderer)
 
     def _resize(self, *args, **kwargs):
-        ""
+        """Resize the figure according to chart size"""
+        self.draw(self.build_figure())
+
+    def build_figure(self):
+        """Build a figure with the same side as the chart."""
         # 100 is the default DPI for figure at time of writing.
         dpi = 100
         figure = Figure(
@@ -64,7 +68,7 @@ class Chart(Canvas, FigureCanvasBase):
                 self.layout.content_height / dpi
             )
         )
-        self.draw(figure)
+        return figure
 
     @property
     def on_draw(self):

--- a/src/toga_chart/chart.py
+++ b/src/toga_chart/chart.py
@@ -31,7 +31,7 @@ class Chart(Canvas, FigureCanvasBase):
     """
     def __init__(self, id=None, style=None, on_resize=None, on_draw=None, factory=None):
         if on_resize is None:
-            on_resize = self._resize
+            on_resize = self.update
         Canvas.__init__(self, id=id, style=style, on_resize=on_resize, factory=factory)
         self.on_draw = on_draw
 
@@ -54,7 +54,7 @@ class Chart(Canvas, FigureCanvasBase):
 
         figure.draw(renderer)
 
-    def _resize(self, *args, **kwargs):
+    def update(self, *args, **kwargs):
         """Resize the figure according to chart size"""
         self.draw(self.build_figure())
 


### PR DESCRIPTION
The Problem
--------------

At the moment, `Chart` does not allow to redraw a figure manually.
However, it does allow doing so automatically on resize, using a protected method.

My solution
--------------
I introduced a new method called `Chart.build_figure` that creates a figure with the right screen size.
This figure now can be used as a parameter to `Chart.draw`.

Why not simply use `Chart.draw`?
-------------------------------------
This reason is that `Chart.draw` excepts a figure parameter, but that figure might not have the size of the chart.
`Chart._resize` does not except a figure, but it creates a figure that is suitable for the chart size.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
