### PR TITLE
Chart inherit widget

### DIFF
--- a/changes/22.feature.rst
+++ b/changes/22.feature.rst
@@ -1,0 +1,1 @@
+Refactor `Chart` so it will inherit `Widget` instead of `Canvas`

--- a/changes/22.feature.rst
+++ b/changes/22.feature.rst
@@ -1,1 +1,1 @@
-Refactor `Chart` so it will inherit `Widget` instead of `Canvas`
+Chart is a now standalone widget, rather than an extension of a Toga Canvas.

--- a/examples/chart/app.py
+++ b/examples/chart/app.py
@@ -6,21 +6,24 @@ from toga.constants import COLUMN
 
 
 class ExampleChartApp(toga.App):
-    def draw_chart(self, chart, figure, *args, **kwargs):
+    MU = 100  # mean of distribution
+    SIGMA = 15  # standard deviation of distribution
+
+    def set_data(self):
         # Generate some example data
-        mu = 100  # mean of distribution
-        sigma = 15  # standard deviation of distribution
-        x = mu + sigma * np.random.randn(437)
+        self.x = self.MU + self.SIGMA * np.random.randn(437)
+
+    def draw_chart(self, chart, figure, *args, **kwargs):
 
         num_bins = 50
 
         # Add a subplot that is a histogram of the data,
         # using the normal matplotlib API
         ax = figure.add_subplot(1, 1, 1)
-        n, bins, patches = ax.hist(x, num_bins, density=1)
+        n, bins, patches = ax.hist(self.x, num_bins, density=1)
 
         # add a 'best fit' line
-        y = ((1 / (np.sqrt(2 * np.pi) * sigma)) * np.exp(-0.5 * (1 / sigma * (bins - mu))**2))
+        y = ((1 / (np.sqrt(2 * np.pi) * self.SIGMA)) * np.exp(-0.5 * (1 / self.SIGMA * (bins - self.MU))**2))
         ax.plot(bins, y, '--')
 
         ax.set_xlabel('Value')
@@ -29,8 +32,13 @@ class ExampleChartApp(toga.App):
 
         figure.tight_layout()
 
+    def recreate_data(self, widget):
+        self.set_data()
+        self.chart.redraw()
+
     def startup(self):
         np.random.seed(19680801)
+        self.set_data()
 
         # Set up main window
         self.main_window = toga.MainWindow(title=self.name)
@@ -40,6 +48,7 @@ class ExampleChartApp(toga.App):
         self.main_window.content = toga.Box(
             children=[
                 self.chart,
+                toga.Button("Recreate data", on_press=self.recreate_data)
             ],
             style=Pack(direction=COLUMN)
         )

--- a/src/toga_chart/chart.py
+++ b/src/toga_chart/chart.py
@@ -32,7 +32,7 @@ class Chart(Widget):
     """
     def __init__(self, style=None, on_resize=None, on_draw=None, factory=None):
         if on_resize is None:
-            on_resize = self._resize
+            on_resize = self.redraw
         super().__init__(style=style, factory=factory)
         self.canvas = Canvas(style=style, on_resize=on_resize, factory=factory)
         self._impl = self.canvas._impl
@@ -57,8 +57,8 @@ class Chart(Widget):
 
         figure.draw(renderer)
 
-    def _resize(self, *args, **kwargs):
-        ""
+    def redraw(self, *args, **kwargs):
+        """Redraw the chart."""
         # 100 is the default DPI for figure at time of writing.
         dpi = 100
         figure = Figure(

--- a/src/toga_chart/chart.py
+++ b/src/toga_chart/chart.py
@@ -30,10 +30,10 @@ class Chart(Widget):
             implementation of this class with the same name. (optional &
             normally not needed)
     """
-    def __init__(self, style=None, on_resize=None, on_draw=None, factory=None):
+    def __init__(self, id=None, style=None, on_resize=None, on_draw=None, factory=None):
         if on_resize is None:
             on_resize = self.redraw
-        super().__init__(style=style, factory=factory)
+        super().__init__(id=id, style=style, factory=factory)
         self.canvas = Canvas(style=style, on_resize=on_resize, factory=factory)
         self._impl = self.canvas._impl
         self.on_draw = on_draw

--- a/src/toga_chart/chart.py
+++ b/src/toga_chart/chart.py
@@ -32,10 +32,11 @@ class Chart(Widget):
     def __init__(self, id=None, style=None, on_resize=None, on_draw=None, factory=None):
         self.on_draw = on_draw
         if on_resize is None:
-            on_resize = lambda canvas, **kwargs: self.redraw()
+            on_resize = self._on_resize
+
+        self.canvas = Canvas(style=style, on_resize=on_resize, factory=factory)
 
         super().__init__(id=id, style=style, factory=factory)
-        self.canvas = Canvas(style=style, on_resize=on_resize, factory=factory)
         self._impl = self.canvas._impl
 
     def _set_app(self, app):
@@ -43,6 +44,14 @@ class Chart(Widget):
 
     def _set_window(self, window):
         self.canvas.window = window
+
+    @property
+    def layout(self):
+        return self.canvas.layout
+
+    @layout.setter
+    def layout(self, value):
+        self.canvas.layout = value
 
     def _draw(self, figure):
         """Draws the matplotlib figure onto the canvas
@@ -62,6 +71,9 @@ class Chart(Widget):
             self.on_draw(self, figure=figure)
 
         figure.draw(renderer)
+
+    def _on_resize(self, widget, **kwargs):
+        self.redraw()
 
     def redraw(self):
         """Redraw the chart."""

--- a/src/toga_chart/chart.py
+++ b/src/toga_chart/chart.py
@@ -5,13 +5,12 @@ from matplotlib.backend_bases import FigureCanvasBase, RendererBase
 from matplotlib.figure import Figure
 from matplotlib.path import Path
 from matplotlib.transforms import Affine2D
-from toga import Widget
 
+from toga import Canvas, Widget
 from toga.colors import color as parse_color
 from toga.colors import rgba
 from toga.fonts import CURSIVE, FANTASY, MONOSPACE, SANS_SERIF, SERIF, Font
 from toga.handlers import wrapped_handler
-from toga.widgets.canvas import Canvas
 
 
 class Chart(Widget):
@@ -31,14 +30,21 @@ class Chart(Widget):
             normally not needed)
     """
     def __init__(self, id=None, style=None, on_resize=None, on_draw=None, factory=None):
+        self.on_draw = on_draw
         if on_resize is None:
-            on_resize = self.redraw
+            on_resize = lambda canvas, **kwargs: self.redraw()
+
         super().__init__(id=id, style=style, factory=factory)
         self.canvas = Canvas(style=style, on_resize=on_resize, factory=factory)
         self._impl = self.canvas._impl
-        self.on_draw = on_draw
 
-    def draw(self, figure):
+    def _set_app(self, app):
+        self.canvas.app = app
+
+    def _set_window(self, window):
+        self.canvas.window = window
+
+    def _draw(self, figure):
         """Draws the matplotlib figure onto the canvas
 
         Args:
@@ -57,7 +63,7 @@ class Chart(Widget):
 
         figure.draw(renderer)
 
-    def redraw(self, *args, **kwargs):
+    def redraw(self):
         """Redraw the chart."""
         # 100 is the default DPI for figure at time of writing.
         dpi = 100
@@ -67,7 +73,7 @@ class Chart(Widget):
                 self.layout.content_height / dpi
             )
         )
-        self.draw(figure)
+        self._draw(figure)
 
     @property
     def on_draw(self):


### PR DESCRIPTION
Fixes #21 

Chart now inherits `toga.Widget` directly instead of `Canvas`.

Moreover, renamed the internal `Chart._resize` method to `Chart.redraw`. Now users can redraw the chart manually when needed.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
