### PR TITLE
Pin Sphinx on Python 3.8.

### DIFF
--- a/changes/32.misc.rst
+++ b/changes/32.misc.rst
@@ -1,2 +1,1 @@
-Updated furo from 2023.7.26 to 2023.8.19.
-Pinned Sphinx on Python 3.8 because they deprecated it.
+A separate Sphinx pin was added for Python 3.8, because Sphinx 7.2 deprecated sypport for Python 3.8.

--- a/changes/32.misc.rst
+++ b/changes/32.misc.rst
@@ -1,1 +1,2 @@
 Updated furo from 2023.7.26 to 2023.8.19.
+Pinned Sphinx on Python 3.8 because they deprecated it.

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,8 +56,9 @@ dev =
 docs =
     furo == 2023.8.19
     pyenchant == 3.2.2
-    sphinx == 7.2.2 ; python_version >= '3.9'
+    # Sphinx 7.2 deprecated support for Python 3.8
     sphinx == 7.1.2 ; python_version < '3.9'
+    sphinx == 7.2.2 ; python_version >= '3.9'
     sphinx_tabs == 3.4.1
     sphinx-autobuild == 2021.3.14
     sphinx-copybutton == 0.5.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,7 +56,8 @@ dev =
 docs =
     furo == 2023.8.19
     pyenchant == 3.2.2
-    sphinx == 7.2.2
+    sphinx == 7.2.2 ; python_version >= '3.9'
+    sphinx == 7.1.2 ; python_version < '3.9'
     sphinx_tabs == 3.4.1
     sphinx-autobuild == 2021.3.14
     sphinx-copybutton == 0.5.2


### PR DESCRIPTION
This PR fixes #33 by pinning Sphinx on Python 3.8 to the last version that supported Python 3.8. It uses [environment markers](https://pip.pypa.io/en/stable/reference/requirement-specifiers/#requirement-specifiers) to avoid changing the Sphinx version on more recent Python versions.

## PR Checklist:

- [ ] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
