### PR TITLE
Avoid installing PyGObject to run pre-commit

### DIFF
--- a/.github/workflows/pre-commit-update.yml
+++ b/.github/workflows/pre-commit-update.yml
@@ -10,3 +10,5 @@ jobs:
     name: Update pre-commit
     uses: beeware/.github/.github/workflows/pre-commit-update.yml@main
     secrets: inherit
+    with:
+      pre-commit-source: pre-commit

--- a/changes/57.misc.rst
+++ b/changes/57.misc.rst
@@ -1,0 +1,1 @@
+The CI job to update pre-commit hooks now successfully runs.


### PR DESCRIPTION
- By default, the pre-commit update CI job installs `.[dev]` to ensure the intended version of pre-commit is used. For toga-chart, that ultimately means building PyGObject and that requires certain system packages to be installed.
- To avoid all this, the latest version of pre-commit is used instead.

E.g. https://github.com/beeware/toga-chart/actions/runs/6605982794/job/17941726255

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
