### PR TITLE
Issue 34

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ package_dir=
     = src
 install_requires =
     toga >= 0.3.1
-    matplotlib >= 3.0.3
+    matplotlib >= 3.7.3
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
<!--- Describe your changes in detail -->
Attempt to install all of setuptools for 3.12 because distutils has been deprecated.

I'm opening this PR to see how the CI stack works.  If I should be doing this locally or if there's a less intrusive way please let me know!

<!--- What problem does this change solve? -->
At the least, get CI passing, 
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
https://github.com/beeware/toga-chart/issues/34

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
