### PR TITLE
Upgrade `upload-artifact` and `download-artifact` actions to v4 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,8 @@ jobs:
 
   package:
     name: Python Package
-    uses: beeware/.github/.github/workflows/python-package-create.yml@main
+#    uses: beeware/.github/.github/workflows/python-package-create.yml@main
+    uses: rmartin16/.github-beeware/.github/workflows/python-package-create.yml@artifacts
     with:
       runner-os: macos-latest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Get packages
-      uses: actions/download-artifact@v3.0.2
+      uses: actions/download-artifact@v4.1.0
       with:
         name: ${{ needs.package.outputs.artifact-name }}
         path: dist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,7 @@ jobs:
 
   package:
     name: Python Package
-#    uses: beeware/.github/.github/workflows/python-package-create.yml@main
-    uses: rmartin16/.github-beeware/.github/workflows/python-package-create.yml@artifacts
+    uses: beeware/.github/.github/workflows/python-package-create.yml@main
     with:
       runner-os: macos-latest
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
           python-version: "3.x"
 
       - name: Get packages
-        uses: actions/download-artifact@v3.0.2
+        uses: actions/download-artifact@v4.1.0
         with:
           name: ${{ needs.ci.outputs.artifact-name }}
           path: dist

--- a/changes/78.misc.rst
+++ b/changes/78.misc.rst
@@ -1,0 +1,1 @@
+The ``upload-artifact`` and ``download-artifact`` CI actions were upgraded to v4.


### PR DESCRIPTION
## Changes
- RE: https://github.com/beeware/.github/issues/77
- Bump `upload-artifact` and `download-artifact` actions to v4
- 🚨 Dependent on https://github.com/beeware/.github/pull/78 🚨 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
