### PR TITLE
Bump black-pre-commit-mirror from 24.1.1 to 24.2.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
       - id: pyupgrade
         args: [--py38-plus]
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.1.1
+    rev: 24.2.0
     hooks:
     - id: black
   - repo: https://github.com/PyCQA/flake8

--- a/changes/97.misc.rst
+++ b/changes/97.misc.rst
@@ -1,0 +1,1 @@
+The ``pre-commit`` hook for ``black-pre-commit-mirror`` was updated to its latest version.


### PR DESCRIPTION
Bumps `pre-commit` hook for `black-pre-commit-mirror` from 24.1.1 to 24.2.0 and ran the update against the repo.