### PR TITLE
Add explicit RTD version pin, and protect against Sphinx 8 deprecations.

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,7 +7,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3"
+    python: "3.12"
   jobs:
     post_checkout:
       # RTD defaults to a depth of 50 but we may require much more git history to

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,6 +7,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
+    # Docs are always built on Python 3.12. See also the tox config.
     python: "3.12"
   jobs:
     post_checkout:

--- a/changes/153.doc.rst
+++ b/changes/153.doc.rst
@@ -1,1 +1,1 @@
-Building toga-charts's documentation now requires the use of Python 3.12.
+Building toga-chart's documentation now requires the use of Python 3.12.

--- a/changes/153.doc.rst
+++ b/changes/153.doc.rst
@@ -1,0 +1,1 @@
+Building toga-charts's documentation now requires the use of Python 3.12.

--- a/changes/153.misc.rst
+++ b/changes/153.misc.rst
@@ -1,0 +1,1 @@
+The environment for RTD builds was pinned, and protection for Sphinx updates was added.

--- a/changes/153.misc.rst
+++ b/changes/153.misc.rst
@@ -1,1 +1,0 @@
-The environment for RTD builds was pinned, and protection for Sphinx updates was added.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dev = [
     "tox == 4.16.0",
     "toga-dummy >= 0.4.0",
 ]
-# Docs are always built on Py3.12; see RTD and tox config files.
+# Docs are always built on a specific Python version; see RTD and tox config files.
 docs = [
     "furo == 2024.7.18",
     "pyenchant == 3.2.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,18 +50,13 @@ dev = [
     "tox == 4.16.0",
     "toga-dummy >= 0.4.0",
 ]
+# Docs are always built on Py3.12; see RTD and tox config files.
 docs = [
     "furo == 2024.7.18",
     "pyenchant == 3.2.2",
-    # Sphinx 7.2 deprecated support for Python 3.8
-    # Sphinx 8.0 deprecated support for Python 3.9
-    "sphinx == 7.1.2 ; python_version < '3.9'",
-    "sphinx == 7.4.7 ; python_version == '3.9'",
-    "sphinx == 7.4.7 ; python_version >= '3.10'",
+    "sphinx == 7.4.7",
     "sphinx_tabs == 3.4.5",
-    # sphinx-autobuild 2024.2.4 deprecated support for Python 3.8
-    "sphinx-autobuild == 2021.3.14 ; python_version < '3.9'",
-    "sphinx-autobuild == 2024.4.16 ; python_version >= '3.9'",
+    "sphinx-autobuild == 2024.4.16",
     "sphinx-copybutton == 0.5.2",
     "sphinxcontrib-spelling == 8.0.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,10 +54,14 @@ docs = [
     "furo == 2024.7.18",
     "pyenchant == 3.2.2",
     # Sphinx 7.2 deprecated support for Python 3.8
+    # Sphinx 8.0 deprecated support for Python 3.9
     "sphinx == 7.1.2 ; python_version < '3.9'",
-    "sphinx == 7.4.7 ; python_version >= '3.9'",
+    "sphinx == 7.4.7 ; python_version == '3.9'",
+    "sphinx == 7.4.7 ; python_version >= '3.10'",
     "sphinx_tabs == 3.4.5",
-    "sphinx-autobuild == 2024.4.16",
+    # sphinx-autobuild 2024.2.4 deprecated support for Python 3.8
+    "sphinx-autobuild == 2021.3.14 ; python_version < '3.9'",
+    "sphinx-autobuild == 2024.4.16 ; python_version >= '3.9'",
     "sphinx-copybutton == 0.5.2",
     "sphinxcontrib-spelling == 8.0.0",
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -35,7 +35,10 @@ build_dir = {[docs]docs_dir}{/}_build
 sphinx_args = --show-traceback --fail-on-warning --keep-going --jobs auto
 
 [testenv:docs{,-lint,-all,-live}]
+# Docs are always built on Python 3.12. See also the RTD config.
 base_python = py312
+# give sphinx-autobuild time to shutdown http server
+suicide_timeout = 1
 package = wheel
 wheel_build_env = .pkg
 extras = docs

--- a/tox.ini
+++ b/tox.ini
@@ -32,16 +32,10 @@ commands =
 [docs]
 docs_dir = {tox_root}{/}docs
 build_dir = {[docs]docs_dir}{/}_build
-# replace when Sphinx>=7.3 and Python 3.8 is dropped:
-#  -T => --show-traceback
-#  -W => --fail-on-warning
-#  -b => --builder
-#  -v => --verbose
-#  -a => --write-all
-#  -E => --fresh-env
-sphinx_args = -T -W --keep-going --jobs auto
+sphinx_args = --show-traceback --fail-on-warning --keep-going --jobs auto
 
 [testenv:docs{,-lint,-all,-live}]
+base_python = py312
 package = wheel
 wheel_build_env = .pkg
 extras = docs
@@ -51,8 +45,8 @@ passenv =
     #     export PYENCHANT_LIBRARY_PATH=/opt/homebrew/lib/libenchant-2.2.dylib
     PYENCHANT_LIBRARY_PATH
 commands =
-    !lint-!all-!live : python -m sphinx {[docs]sphinx_args} {posargs} -b html {[docs]docs_dir} {[docs]build_dir}{/}html
-    lint : python -m sphinx {[docs]sphinx_args} {posargs} -b spelling {[docs]docs_dir} {[docs]build_dir}{/}spell
-    lint : python -m sphinx {[docs]sphinx_args} {posargs} -b linkcheck {[docs]docs_dir} {[docs]build_dir}{/}links
-    all  : python -m sphinx {[docs]sphinx_args} {posargs} -v -a -E -b html {[docs]docs_dir} {[docs]build_dir}{/}html
-    live : sphinx-autobuild {[docs]sphinx_args} {posargs} -b html {[docs]docs_dir} {[docs]build_dir}{/}live
+    !lint-!all-!live : python -m sphinx {[docs]sphinx_args} {posargs} --builder html {[docs]docs_dir} {[docs]build_dir}{/}html
+    lint : python -m sphinx {[docs]sphinx_args} {posargs} --builder spelling {[docs]docs_dir} {[docs]build_dir}{/}spell
+    lint : python -m sphinx {[docs]sphinx_args} {posargs} --builder linkcheck {[docs]docs_dir} {[docs]build_dir}{/}links
+    all  : python -m sphinx {[docs]sphinx_args} {posargs} --verbose --write-all --fresh-env --builder html {[docs]docs_dir} {[docs]build_dir}{/}html
+    live : sphinx-autobuild {[docs]sphinx_args} {posargs} --builder html {[docs]docs_dir} {[docs]build_dir}{/}live


### PR DESCRIPTION
To ensure a consistent and repeatable build environment, use a hard version pin on the RTD environment.

Also adds a pin to Sphinx on Python 3.9, as Sphinx 8 deprecates Python 3.9 support; and a pin to sphinx-autobuild on Python 3.8.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
