### PR TITLE
Drop support for Python 3.8, add 3.13.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,10 +57,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         include:
           - experimental: false
-          # - python-version: "3.13-dev"
+          # - python-version: "3.14"
           #   experimental: true
 
     steps:
@@ -73,6 +73,7 @@ jobs:
       uses: actions/setup-python@v5.2.0
       with:
         python-version: ${{ matrix.python-version }}
+        allow-prereleases: true
 
     - name: Get packages
       uses: actions/download-artifact@v4.1.8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     rev: v3.18.0
     hooks:
       - id: pyupgrade
-        args: [--py38-plus]
+        args: [--py39-plus]
   - repo: https://github.com/psf/black-pre-commit-mirror
     rev: 24.10.0
     hooks:

--- a/changes/183.feature.rst
+++ b/changes/183.feature.rst
@@ -1,0 +1,1 @@
+Support for Python 3.13 was added.

--- a/changes/183.removal.rst
+++ b/changes/183.removal.rst
@@ -1,0 +1,1 @@
+Support for Python 3.8 was dropped.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dynamic = ["version"]
 name = "toga-chart"
 description = "A Toga matplotlib backend."
 readme = "README.rst"
-requires-python = ">= 3.8"
+requires-python = ">= 3.9"
 license.text = "New BSD"
 authors = [
     {name="Russell Keith-Magee", email="russell@keith-magee.com"},
@@ -28,11 +28,11 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Software Development",
     "Topic :: Software Development :: User Interfaces",
@@ -42,9 +42,7 @@ classifiers = [
 # Extras used by developers *of* briefcase are pinned to specific versions to
 # ensure environment consistency.
 dev = [
-    # Pre-commit 3.6.0 deprecated support for Python 3.8
-    "pre-commit == 3.5.0 ; python_version < '3.9'",
-    "pre-commit == 4.0.1 ; python_version >= '3.9'",
+    "pre-commit == 4.0.1",
     "pytest == 8.3.3",
     "setuptools_scm == 8.1.0",
     "tox == 4.21.2",

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ extend-ignore =
     E203,
 
 [tox]
-envlist = towncrier-check,docs{,-lint,-all},package,py{38,39,310,311,312}
+envlist = towncrier-check,docs{,-lint,-all},package,py{39,310,311,312,313}
 skip_missing_interpreters = true
 
 [testenv]


### PR DESCRIPTION
Python 3.8 is EOL, so we can drop support.

Python 3.13 is now available, so we can add 3.13 to the test matrix.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
