### PR TITLE
Bump ruff-pre-commit from v0.12.12 to v0.13.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.12.12
+    rev: v0.13.0
     hooks:
       - id: ruff-check
         args: [ --fix ]


### PR DESCRIPTION
Bumps `pre-commit` hook for `ruff-pre-commit` from v0.12.12 to v0.13.0 and ran the update against the repo.