### PR TITLE
Add zizmor pre-commit hook and fix all reported GHA security issues

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,13 +12,19 @@ updates:
     directory: "/"
     patterns: ["*"]
     multi-ecosystem-group: "dependencies"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "pip"
     directory: "/"
     patterns: ["*"]
     multi-ecosystem-group: "dependencies"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "pre-commit"
     directory: "/"
     patterns: ["*"]
     multi-ecosystem-group: "dependencies"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/check-pr-template.yml
+++ b/.github/workflows/check-pr-template.yml
@@ -6,5 +6,6 @@ on:
 
 jobs:
   check-pr-template:
+    permissions: {}
     name: Check PR template
-    uses: beeware/.github/.github/workflows/pr-checklist.yml@main
+    uses: beeware/.github/.github/workflows/pr-checklist.yml@741cc5a311012ee0ee195938889a337449d01eeb  # main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-# Read-only by default. Called reusable workflows and individual jobs
-# declare any additional permissions they require.
 permissions:
   contents: read
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Read-only by default. Called reusable workflows and individual jobs
+# declare any additional permissions they require.
+permissions:
+  contents: read
+
 defaults:
   run:
     shell: bash
@@ -30,13 +35,15 @@ env:
 jobs:
   pre-commit:
     name: Pre-commit checks
-    uses: beeware/.github/.github/workflows/pre-commit-run.yml@main
+    permissions: {}
+    uses: beeware/.github/.github/workflows/pre-commit-run.yml@741cc5a311012ee0ee195938889a337449d01eeb  # main
     with:
       pre-commit-source: "--group pre-commit"
 
   towncrier:
     name: Check towncrier
-    uses: beeware/.github/.github/workflows/towncrier-run.yml@main
+    permissions: {}
+    uses: beeware/.github/.github/workflows/towncrier-run.yml@741cc5a311012ee0ee195938889a337449d01eeb  # main
     with:
       tox-source: "--group tox-uv"
 
@@ -46,7 +53,7 @@ jobs:
       id-token: write
       contents: read
       attestations: write
-    uses: beeware/.github/.github/workflows/python-package-create.yml@main
+    uses: beeware/.github/.github/workflows/python-package-create.yml@741cc5a311012ee0ee195938889a337449d01eeb  # main
     with:
       attest: ${{ inputs.attest-package }}
 
@@ -54,6 +61,9 @@ jobs:
     name: Python compatibility test
     needs: [ pre-commit, towncrier, package ]
     runs-on: macos-latest
+    permissions:
+      contents: read
+      actions: read
     strategy:
       fail-fast: false
       matrix:
@@ -61,18 +71,19 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v7.0.0
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       with:
         fetch-depth: 0
+        persist-credentials: false
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v6.3.0
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
       with:
         python-version: ${{ matrix.python-version }}
         allow-prereleases: true
 
     - name: Get packages
-      uses: actions/download-artifact@v8.0.1
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
       with:
         name: ${{ needs.package.outputs.artifact-name }}
         path: dist

--- a/.github/workflows/dependabot-changenote.yml
+++ b/.github/workflows/dependabot-changenote.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   changenote:
+    permissions: {}
     name: Dependabot Change Note
-    uses: beeware/.github/.github/workflows/dependabot-changenote.yml@main
-    secrets: inherit
+    uses: beeware/.github/.github/workflows/dependabot-changenote.yml@741cc5a311012ee0ee195938889a337449d01eeb  # main
+    secrets:
+      BRUTUS_PAT_TOKEN: ${{ secrets.BRUTUS_PAT_TOKEN }}

--- a/.github/workflows/new-issue.yml
+++ b/.github/workflows/new-issue.yml
@@ -9,10 +9,11 @@ on:
 
 jobs:
   add-to-project:
+    permissions: {}
     name: Add issue to BeeWare project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v2.0.0
+      - uses: actions/add-to-project@5afcf98fcd03f1c2f92c3c83f58ae24323cc57fd  # v2.0.0
         with:
           project-url: https://github.com/orgs/beeware/projects/1
           github-token: ${{ secrets.BRUTUS_PAT_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
       # This permission is required for trusted publishing.
       id-token: write
     steps:
-      - uses: dsaltares/fetch-gh-release-asset@1.1.2
+      - uses: dsaltares/fetch-gh-release-asset@aa2ab1243d6e0d5b405b973c89fa4d06a2d0fff7  # 1.1.2
         with:
           version: tags/${{ github.event.release.tag_name }}
           # This next line is *not* a bash filename expansion - it's a regex. We
@@ -23,4 +23,4 @@ jobs:
           target: dist/
 
       - name: Publish release to production PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247  # release/v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,4 +23,4 @@ jobs:
           target: dist/
 
       - name: Publish release to production PyPI
-        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247  # release/v1
+        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247  # v1.14.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,7 @@
 name: Create Release
 
+permissions: {}
+
 on:
   push:
     tags:
@@ -8,14 +10,17 @@ on:
 jobs:
   ci:
     name: CI
+    permissions: {}
     uses: ./.github/workflows/ci.yml
     with:
       attest-package: "true"
 
   docs:
     name: Verify Docs Build
-    uses: beeware/.github/.github/workflows/docs-build-verify.yml@main
-    secrets: inherit
+    permissions: {}
+    uses: beeware/.github/.github/workflows/docs-build-verify.yml@741cc5a311012ee0ee195938889a337449d01eeb  # main
+    secrets:
+      RTD_API_TOKEN: ${{ secrets.RTD_API_TOKEN }}
     with:
       project-name: "toga-chart"
       project-version: ${{ github.ref_name }}
@@ -26,6 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      actions: read
       # This permission is required for trusted publishing.
       id-token: write
     steps:
@@ -34,12 +40,12 @@ jobs:
           echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_ENV
 
       - name: Set up Python
-        uses: actions/setup-python@v6.3.0
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:
           python-version: "3.x"
 
       - name: Get Package
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: ${{ needs.ci.outputs.artifact-name }}
           path: dist
@@ -55,14 +61,20 @@ jobs:
           test $(python -c "from toga_chart import __version__; print(__version__)") = $VERSION
 
       - name: Create release
-        uses: ncipollo/release-action@v1.21.0
-        with:
-          name: ${{ env.VERSION }}
-          draft: true
-          artifacts: dist/*
-          artifactErrorsFailBuild: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          shopt -s nullglob
+          artifacts=(dist/*)
+          if (( ${#artifacts[@]} == 0 )); then
+            echo "No artifacts found in dist/"
+            exit 1
+          fi
+          gh release create "${GITHUB_REF_NAME}" "${artifacts[@]}" \
+            --draft \
+            --title "${VERSION}"
 
       - name: Publish release to Test PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247  # release/v1
         with:
           repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,17 +64,13 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          shopt -s nullglob
-          artifacts=(dist/*)
-          if (( ${#artifacts[@]} == 0 )); then
-            echo "No artifacts found in dist/"
-            exit 1
-          fi
-          gh release create "${GITHUB_REF_NAME}" "${artifacts[@]}" \
+          gh release create "${GITHUB_REF_NAME}" \
+            --title "${VERSION}" \
             --draft \
-            --title "${VERSION}"
+            --verify-tag \
+            dist/*
 
       - name: Publish release to Test PyPI
-        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247  # release/v1
+        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247  # v1.14.0
         with:
           repository-url: https://test.pypi.org/legacy/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,3 +18,7 @@ repos:
     rev: v0.2.28
     hooks:
       - id: rumdl
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: v1.27.0
+    hooks:
+      - id: zizmor

--- a/changes/335.misc.md
+++ b/changes/335.misc.md
@@ -1,0 +1,1 @@
+Added zizmor to the pre-commit configuration to audit GitHub Actions workflows for security issues.


### PR DESCRIPTION
## Description

Adds zizmor to the project's pre-commit configuration and fixes all reported GitHub Actions security issues.

## Changes

- Pin all unpinned action and reusable-workflow references to full commit SHAs
- Add `persist-credentials: false` to checkout steps
- Add zizmor to `.pre-commit-config.yaml` (v1.27.0)
- Add explicit permissions where safe (release.yml, CI, reusable workflow callers)
- Replace `secrets: inherit` with explicit secret passing
- Replace `ncipollo/release-action` with `gh release create`
- Add a 7-day Dependabot cooldown

## Verification

- `pre-commit run --all-files` passes (including zizmor)
- `tox -e towncrier-check` passes
- `tox -e py` passes
- zizmor: 0 findings

## PR Checklist

- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool

Reference: beeware/.github#378

Fixes #335
Fixes #334