### PR TITLE
Add zizmor.yml and relax pins on beeware/.github actions

### DIFF
--- a/.github/workflows/check-pr-template.yml
+++ b/.github/workflows/check-pr-template.yml
@@ -8,4 +8,4 @@ jobs:
   check-pr-template:
     permissions: {}
     name: Check PR template
-    uses: beeware/.github/.github/workflows/pr-checklist.yml@741cc5a311012ee0ee195938889a337449d01eeb  # main
+    uses: beeware/.github/.github/workflows/pr-checklist.yml@main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,14 +34,14 @@ jobs:
   pre-commit:
     name: Pre-commit checks
     permissions: {}
-    uses: beeware/.github/.github/workflows/pre-commit-run.yml@741cc5a311012ee0ee195938889a337449d01eeb  # main
+    uses: beeware/.github/.github/workflows/pre-commit-run.yml@main
     with:
       pre-commit-source: "--group pre-commit"
 
   towncrier:
     name: Check towncrier
     permissions: {}
-    uses: beeware/.github/.github/workflows/towncrier-run.yml@741cc5a311012ee0ee195938889a337449d01eeb  # main
+    uses: beeware/.github/.github/workflows/towncrier-run.yml@main
     with:
       tox-source: "--group tox-uv"
 
@@ -51,7 +51,7 @@ jobs:
       id-token: write
       contents: read
       attestations: write
-    uses: beeware/.github/.github/workflows/python-package-create.yml@741cc5a311012ee0ee195938889a337449d01eeb  # main
+    uses: beeware/.github/.github/workflows/python-package-create.yml@main
     with:
       attest: ${{ inputs.attest-package }}
 

--- a/.github/workflows/dependabot-changenote.yml
+++ b/.github/workflows/dependabot-changenote.yml
@@ -9,6 +9,6 @@ jobs:
   changenote:
     permissions: {}
     name: Dependabot Change Note
-    uses: beeware/.github/.github/workflows/dependabot-changenote.yml@741cc5a311012ee0ee195938889a337449d01eeb  # main
+    uses: beeware/.github/.github/workflows/dependabot-changenote.yml@main
     secrets:
       BRUTUS_PAT_TOKEN: ${{ secrets.BRUTUS_PAT_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
   docs:
     name: Verify Docs Build
     permissions: {}
-    uses: beeware/.github/.github/workflows/docs-build-verify.yml@741cc5a311012ee0ee195938889a337449d01eeb  # main
+    uses: beeware/.github/.github/workflows/docs-build-verify.yml@main
     secrets:
       RTD_API_TOKEN: ${{ secrets.RTD_API_TOKEN }}
     with:

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,9 @@
+rules:
+  unpinned-uses:
+    config:
+      # Allow BeeWare-provided actions to be unpinned. If an attacker is in a
+      # position to exploit those action, they're probably able to exploit
+      # repositories directly; and it's significantly easier for our internal
+      # actions to automatically be the most recent versions.
+      policies:
+        beeware/*: ref-pin

--- a/changes/339.misc.md
+++ b/changes/339.misc.md
@@ -1,0 +1,1 @@
+Added a zizmor configuration to relax pinning requirements for BeeWare-maintained GitHub Actions.


### PR DESCRIPTION
Adds a `.github/zizmor.yml` config that allows `beeware/.github` action references to stay pinned to a ref (e.g. `@main`) instead of a full commit hash, and relaxes the existing `beeware/.github` action pins accordingly.

## PR Checklist:
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [x] This PR was generated or assisted using an AI tool
Assisted-by: Claude Sonnet 5
